### PR TITLE
Use static, dependabot-parseable forms in gemspec

### DIFF
--- a/autographql.gemspec
+++ b/autographql.gemspec
@@ -4,7 +4,7 @@ Gem::Specification.new do |s|
   s.files       = `git ls-files * ':!:spec'`.split("\n")
   s.homepage    = 'https://github.com/dpep/autographql_rb'
   s.license     = 'MIT'
-  s.name        = File.basename(__FILE__, ".gemspec")
+  s.name        = 'autographql'
   s.summary     = 'AutoGraphQL'
   s.version     = '0.0.4'
 


### PR DESCRIPTION
## Summary

Dependabot's gemspec parser is **static** — it doesn't eval Ruby, it reads the AST and only handles literal `s.name = "string"` and `s.version = SomeConst::VERSION`. The dynamic forms we had defeated that.

When dependabot can't extract the version statically it falls back to `0.0.1` and writes that into `Gemfile.lock`, which then fails CI in frozen mode (gem version mismatch). See dpep/meddleware_rb#18 for the original diagnosis.

This PR switches to the canonical Bundler-scaffold shape:

```ruby
s.name    = "autographql"
```


## Test plan

- [x] `Bundler.load_gemspec("autographql.gemspec")` parses statically to name=`autographql`, version=`0.0.4`
- [x] `bundle install` runs cleanly

## Pattern reference

- dpep/meddleware_rb#18 (diagnosis)
- dpep/amenable_rb#7 (template)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
